### PR TITLE
perf: use smart pointers instead of owned strings

### DIFF
--- a/src/cmds/assume_role.rs
+++ b/src/cmds/assume_role.rs
@@ -4,6 +4,7 @@ use crate::{
     sts::{extract_sts_err, StsAction},
 };
 use async_trait::async_trait;
+use std::borrow::Cow;
 
 #[derive(clap::Parser, Debug, Default)]
 pub struct AssumeRole {
@@ -39,8 +40,11 @@ impl ProfileName for AssumeRole {
 }
 
 #[async_trait]
-impl StsAction for AssumeRole {
-    type Output = ShortTermProfile;
+impl<'a> StsAction for &'a AssumeRole {
+    type Output = ShortTermProfile<'a>;
+
+    const DEFAULT_DURATION: i32 = 3600;
+
     async fn execute(
         &self,
         config: &Config,
@@ -53,19 +57,23 @@ impl StsAction for AssumeRole {
             .assume_role()
             .set_role_arn(Some(self.role_arn.clone()))
             .set_role_session_name(Some(self.role_name.clone()))
-            .set_serial_number(Some(lt_profile.mfa_device.clone()))
+            .set_serial_number(Some(lt_profile.mfa_device.to_string()))
             .set_token_code(Some(mfa_token))
-            .set_duration_seconds(config.duration.or(Some(3600)))
+            .set_duration_seconds(config.duration.or(Some(Self::DEFAULT_DURATION)))
             .send()
             .await
             .map_err(extract_sts_err)?;
-        let mut stp = ShortTermProfile::try_from(output.credentials())?;
-        let assumed_role = output.assumed_role_user().unwrap();
+
+        let mut stp = ShortTermProfile::try_from(output.credentials)?;
+
         // Assumed_role_arn is the user input role_arn, not the actual
         // role_arn returned by STS
-        stp.assumed_role_arn = Some(self.role_arn.clone());
+        stp.assumed_role_arn = Some(Cow::Borrowed(&self.role_arn));
         // Assumed_role_id is the actual role_id returned by STS
-        stp.assumed_role_id = Some(assumed_role.assumed_role_id().unwrap().to_string());
+        stp.assumed_role_id = output
+            .assumed_role_user
+            .map(|v| v.assumed_role_id)
+            .unwrap_or_default();
 
         Ok(stp)
     }

--- a/src/cmds/session_token.rs
+++ b/src/cmds/session_token.rs
@@ -1,10 +1,9 @@
-use async_trait::async_trait;
-
 use crate::{
     config::Config,
     profile::{LongTermProfile, ProfileName, ShortTermProfile},
     sts::{extract_sts_err, StsAction},
 };
+use async_trait::async_trait;
 
 #[derive(clap::Parser, Debug, Default)]
 pub struct SessionToken;
@@ -33,7 +32,7 @@ impl<'a> StsAction for &'a SessionToken {
             .get_session_token()
             .serial_number(lt_profile.mfa_device.to_string())
             .duration_seconds(config.duration.unwrap_or(Self::DEFAULT_DURATION))
-            .token_code(mfa_token.to_string())
+            .token_code(mfa_token)
             .send()
             .await
             .map_err(extract_sts_err)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,7 +58,9 @@ impl Config {
 
     fn validate_credentials_path(&mut self) -> anyhow::Result<()> {
         if self.credentials.is_relative() {
-            self.credentials = dirs::home_dir().unwrap().join(self.credentials.as_path());
+            self.credentials = dirs::home_dir()
+                .expect("Cannot find home directory")
+                .join(self.credentials.as_path());
         }
         if !self.credentials.is_file() {
             anyhow::bail!("The credentials file does not exist");

--- a/src/sts.rs
+++ b/src/sts.rs
@@ -11,6 +11,9 @@ use aws_sdk_sts::{
 #[async_trait]
 pub trait StsAction {
     type Output;
+
+    const DEFAULT_DURATION: i32;
+
     async fn execute(
         &self,
         config: &Config,
@@ -26,7 +29,7 @@ pub trait StsAction {
     }
 }
 
-impl LongTermProfile {
+impl<'a> LongTermProfile<'a> {
     pub async fn create_client(&self) -> Client {
         let credentials =
             Credentials::from_keys(self.access_key.clone(), self.secret_key.clone(), None);


### PR DESCRIPTION
- In many cases, we don't need owned data. The profile structs now borrow their content from the file handler and sts responses