### PR TITLE
feat!: align and cleanup env variables and help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,6 @@ cmds.sh
 
 **/dist
 **/node_modules
-**/.pnp.*
-**/.yarn/*
-**/!.yarn/patches
-**/!.yarn/plugins
-**/!.yarn/releases
-**/!.yarn/sdks
-**/!.yarn/versions
+
+# Auto-generated CLI output for the readme
+help

--- a/cli-helpgen.sh
+++ b/cli-helpgen.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cargo build
+
+for cmd in session-token \
+            assume-role \
+            list \
+            clean
+do
+   ./target/debug/mfaws $cmd --help &> ./help/$cmd.txt
+done

--- a/readme.md
+++ b/readme.md
@@ -149,13 +149,13 @@ Options:
       --profile <PROFILE_NAME>
           The AWS credentials profile to use [env: AWS_PROFILE=] [default: default]
       --device <MFA_DEVICE>
-          The MFA Device ARN. This value can also be provided via the ~/.aws/credentials variable 'aws_mfa_device' [env: MFA_DEVICE=]
+          The MFA Device ARN [env: MFA_DEVICE=]
       --credentials-path <CREDENTIALS_PATH>
           Location of the AWS credentials file. Can be a relative path from your home directory or an absolute path to the file [env: AWS_SHARED_CREDENTIALS_FILE=] [default: .aws/credentials]
       --otp <OTP>
           The one-time password from your MFA device
       --duration <DURATION>
-          The duration, in seconds, for which the temporary credentials should remain valid. Defaults to 43200 (12 hours) for session tokens and 3600 (one hour) when assuming a role [env: MFA_DURATION=]
+          The duration, in seconds, for which the temporary credentials should remain valid [env: MFA_DURATION=]
       --short-term-suffix <SHORT_TERM_SUFFIX>
           To identify the auto-generated short-term credential profile [default: short-term]
       --force
@@ -179,11 +179,11 @@ Options:
       --profile <PROFILE_NAME>
           The AWS credentials profile to use [env: AWS_PROFILE=] [default: default]
       --device <MFA_DEVICE>
-          The MFA Device ARN. This value can also be provided via the ~/.aws/credentials variable 'aws_mfa_device' [env: MFA_DEVICE=]
+          The MFA Device ARN [env: MFA_DEVICE=]
       --otp <OTP>
           The one-time password from your MFA device
       --duration <DURATION>
-          The duration, in seconds, for which the temporary credentials should remain valid. Defaults to 43200 (12 hours) for session tokens and 3600 (one hour) when assuming a role [env: MFA_DURATION=]
+          The duration, in seconds, for which the temporary credentials should remain valid [env: MFA_DURATION=]
       --credentials-path <CREDENTIALS_PATH>
           Location of the AWS credentials file. Can be a relative path from your home directory or an absolute path to the file [env: AWS_SHARED_CREDENTIALS_FILE=] [default: .aws/credentials]
       --short-term-suffix <SHORT_TERM_SUFFIX>

--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,8 @@ Usage: mfaws.exe [OPTIONS] <COMMAND>
 Commands:
   assume-role    Temporary credentials for an assumed AWS IAM Role
   session-token  Temporary credentials for an AWS IAM user
+  clean          Remove short-time profiles from your credentials file
+  list           List profiles in your credentials file
   help           Print this message or the help of the given subcommand(s)
 
 Options:
@@ -141,41 +143,25 @@ Usage: mfaws assume-role [OPTIONS] --role-arn <ROLE_ARN>
 
 Options:
       --role-arn <ROLE_ARN>
-          The ARN of the AWS IAM Role you want to assume
-
-          [default: mfa-user]
-
+          The ARN of the AWS IAM Role you want to assume [env: AWS_ROLE_ARN=]
+      --role-session-name <ROLE_NAME>
+          Custom friendly session name when assuming a role [env: AWS_ROLE_SESSION_NAME=] [default: mfa-user]
       --profile <PROFILE_NAME>
-          The AWS credentials profile to use
-
-          [env: AWS_PROFILE=]
-          [default: default]
-
-      --credentials-path <CREDENTIALS_PATH>
-          Location of the AWS credentials file. Can be a relative path from your home directory or an absolute path to the file
-
-          [env: AWS_SHARED_CREDENTIALS_FILE=]
-          [default: .aws/credentials]
-
+          The AWS credentials profile to use [env: AWS_PROFILE=] [default: default]
       --device <MFA_DEVICE>
-          The MFA Device ARN. This value can also be provided via the ~/.aws/credentials variable 'aws_mfa_device'
-
-          [env: MFA_DEVICE=]
-
+          The MFA Device ARN. This value can also be provided via the ~/.aws/credentials variable 'aws_mfa_device' [env: MFA_DEVICE=]
+      --credentials-path <CREDENTIALS_PATH>
+          Location of the AWS credentials file. Can be a relative path from your home directory or an absolute path to the file [env: AWS_SHARED_CREDENTIALS_FILE=] [default: .aws/credentials]
+      --otp <OTP>
+          The one-time password from your MFA device
       --duration <DURATION>
-          The duration, in seconds, for which the temporary credentials should remain valid. Defaults to 43200 (12 hours) for session tokens and 3600 (one hour) when assuming a role
-          [env: MFA_STS_DURATION=]
-
+          The duration, in seconds, for which the temporary credentials should remain valid. Defaults to 43200 (12 hours) for session tokens and 3600 (one hour) when assuming a role [env: MFA_DURATION=]
       --short-term-suffix <SHORT_TERM_SUFFIX>
-          To identify the auto-generated short-term credential profile by [<profile_name>-SHORT_TERM_SUFFIX]
-
-          [default: short-term]
-
+          To identify the auto-generated short-term credential profile [default: short-term]
       --force
           Force the creation of a new short-term profile even if one already exists
-
   -h, --help
-          Print help (see a summary with '-h')
+          Print help
 ```
 
 ### `session-token`
@@ -191,37 +177,21 @@ Usage: mfaws session-token [OPTIONS]
 
 Options:
       --profile <PROFILE_NAME>
-          The AWS credentials profile to use
-
-          [env: AWS_PROFILE=]
-          [default: default]
-
+          The AWS credentials profile to use [env: AWS_PROFILE=] [default: default]
       --device <MFA_DEVICE>
-          The MFA Device ARN. This value can also be provided via the ~/.aws/credentials variable 'aws_mfa_device'
-
-          [env: MFA_DEVICE=]
-
+          The MFA Device ARN. This value can also be provided via the ~/.aws/credentials variable 'aws_mfa_device' [env: MFA_DEVICE=]
+      --otp <OTP>
+          The one-time password from your MFA device
       --duration <DURATION>
-          The duration, in seconds, for which the temporary credentials should remain valid. Defaults to 43200 (12 hours) for session tokens and 3600 (one hour) when assuming a role
-
-          [env: MFA_STS_DURATION=]
-
+          The duration, in seconds, for which the temporary credentials should remain valid. Defaults to 43200 (12 hours) for session tokens and 3600 (one hour) when assuming a role [env: MFA_DURATION=]
       --credentials-path <CREDENTIALS_PATH>
-          Location of the AWS credentials file. Can be a relative path from your home directory or an absolute path to the file
-
-          [env: AWS_SHARED_CREDENTIALS_FILE=]
-          [default: .aws/credentials]
-
+          Location of the AWS credentials file. Can be a relative path from your home directory or an absolute path to the file [env: AWS_SHARED_CREDENTIALS_FILE=] [default: .aws/credentials]
       --short-term-suffix <SHORT_TERM_SUFFIX>
-          To identify the auto-generated short-term credential profile by [<profile_name>-SHORT_TERM_SUFFIX]
-
-          [default: short-term]
-
+          To identify the auto-generated short-term credential profile [default: short-term]
       --force
           Force the creation of a new short-term profile even if one already exists
-
   -h, --help
-          Print help (see a summary with '-h')
+          Print help
 ```
 
 ### `clean`

--- a/src/sts/assume_role.rs
+++ b/src/sts/assume_role.rs
@@ -11,12 +11,14 @@ use crate::{
 pub struct AssumeRole {
     #[arg(
         long = "role-arn",
+        env = "AWS_ROLE_ARN",
         help = "The ARN of the AWS IAM Role you want to assume"
     )]
     pub role_arn: String,
     #[arg(
         long = "role-session-name",
         default_value = "mfa-user",
+        env = "AWS_ROLE_SESSION_NAME",
         help = "Custom friendly session name when assuming a role"
     )]
     pub role_name: String,

--- a/src/sts/config.rs
+++ b/src/sts/config.rs
@@ -7,18 +7,14 @@ pub struct CommonStsConfig {
         help = "The AWS credentials profile to use"
     )]
     pub profile_name: String,
-    #[arg(
-        long = "device",
-        env = "MFA_DEVICE",
-        help = "The MFA Device ARN. This value can also be provided via the ~/.aws/credentials variable 'aws_mfa_device'"
-    )]
+    #[arg(long = "device", env = "MFA_DEVICE", help = "The MFA Device ARN")]
     pub mfa_device: Option<String>,
     #[arg(long, help = "The one-time password from your MFA device")]
     pub otp: Option<String>,
     #[arg(
         long,
         env = "MFA_DURATION",
-        help = "The duration, in seconds, for which the temporary credentials should remain valid. Defaults to 43200 (12 hours) for session tokens and 3600 (one hour) when assuming a role"
+        help = "The duration, in seconds, for which the temporary credentials should remain valid"
     )]
     pub duration: Option<i32>,
     #[arg(

--- a/src/sts/config.rs
+++ b/src/sts/config.rs
@@ -17,9 +17,8 @@ pub struct CommonStsConfig {
     pub otp: Option<String>,
     #[arg(
         long,
-        env = "MFA_STS_DURATION",
-        help = "The duration, in seconds, for which the temporary credentials should remain valid",
-        long_help = "The duration, in seconds, for which the temporary credentials should remain valid. Defaults to 43200 (12 hours) for session tokens and 3600 (one hour) when assuming a role"
+        env = "MFA_DURATION",
+        help = "The duration, in seconds, for which the temporary credentials should remain valid. Defaults to 43200 (12 hours) for session tokens and 3600 (one hour) when assuming a role"
     )]
     pub duration: Option<i32>,
     #[arg(


### PR DESCRIPTION
Align accepted environment variables with the official ones [supported by the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)

Changed (unofficial):
- `MFA_STS_DURATION` -> `MFA_DURATION`

New (official):
- `AWS_ROLE_ARN`
- `AWS_ROLE_SESSION_NAME`

Also cleans up the help commands.